### PR TITLE
Allow to pass api keys as parameters to functions instead of loading from environment

### DIFF
--- a/cmbagent/agents/engineer_response_formatter/engineer_response_formatter.py
+++ b/cmbagent/agents/engineer_response_formatter/engineer_response_formatter.py
@@ -1,7 +1,7 @@
 import os
 from cmbagent.base_agent import BaseAgent
 from pydantic import BaseModel, Field
-from typing import Optional, List
+from typing import Optional
 
 
 class EngineerResponseFormatterAgent(BaseAgent):

--- a/cmbagent/agents/executor_response_formatter/executor_response_formatter.py
+++ b/cmbagent/agents/executor_response_formatter/executor_response_formatter.py
@@ -1,7 +1,7 @@
 import os
 from cmbagent.base_agent import BaseAgent
 from pydantic import BaseModel, Field
-from typing import List, Optional, Literal
+from typing import Literal
 
 
 

--- a/cmbagent/agents/idea_hater_response_formatter/idea_hater_response_formatter.py
+++ b/cmbagent/agents/idea_hater_response_formatter/idea_hater_response_formatter.py
@@ -1,7 +1,7 @@
 import os
 from cmbagent.base_agent import BaseAgent
 from pydantic import BaseModel, Field
-from typing import List, Optional
+from typing import List
 
 
 class Subtasks(BaseModel):

--- a/cmbagent/agents/idea_maker_response_formatter/idea_maker_response_formatter.py
+++ b/cmbagent/agents/idea_maker_response_formatter/idea_maker_response_formatter.py
@@ -1,7 +1,7 @@
 import os
 from cmbagent.base_agent import BaseAgent
 from pydantic import BaseModel, Field
-from typing import List, Optional
+from typing import List
 
 
 class Subtasks(BaseModel):

--- a/cmbagent/agents/planner_response_formatter/planner_response_formatter.py
+++ b/cmbagent/agents/planner_response_formatter/planner_response_formatter.py
@@ -1,7 +1,7 @@
 import os
 from cmbagent.base_agent import BaseAgent
 from pydantic import BaseModel, Field
-from typing import List, Optional, Literal, Dict, Any
+from typing import List, Literal, Dict, Any
 import json
 from pathlib import Path
 
@@ -22,7 +22,7 @@ class PlannerResponse(BaseModel):
         for i, step in enumerate(self.sub_tasks):
             plan_output += f"\n- Step {i + 1}:\n\t* sub-task: {step.sub_task}\n\t* agent in charge: {step.sub_task_agent}\n"
             if step.bullet_points:
-                plan_output += f"\n\t* instructions:\n"
+                plan_output += "\n\t* instructions:\n"
                 for bullet in step.bullet_points:
                     plan_output += f"\t\t- {bullet}\n"
         message = f"""

--- a/cmbagent/agents/researcher_response_formatter/researcher_response_formatter.py
+++ b/cmbagent/agents/researcher_response_formatter/researcher_response_formatter.py
@@ -1,8 +1,6 @@
 import os
 from cmbagent.base_agent import BaseAgent
 from pydantic import BaseModel, Field
-from cmbagent.utils import default_llm_config_list
-from autogen.cmbagent_utils import cmbagent_debug
 import re
 
 

--- a/cmbagent/base_agent.py
+++ b/cmbagent/base_agent.py
@@ -1,8 +1,12 @@
 import os 
 import logging
-from cmbagent.utils import yaml_load_file,GPTAssistantAgent,UserProxyAgent,LocalCommandLineCodeExecutor,file_search_max_num_results
+from cobaya.yaml import yaml_load_file
+from autogen.coding import LocalCommandLineCodeExecutor
+from autogen.agentchat.contrib.gpt_assistant_agent import GPTAssistantAgent
+from autogen.agentchat import UserProxyAgent
+
+from cmbagent.utils import file_search_max_num_results
 from autogen.agentchat import ConversableAgent, UpdateSystemMessage
-# from autogen.cmbagent_utils import cmbagent_debug
 import autogen
 import copy
 

--- a/cmbagent/base_agent.py
+++ b/cmbagent/base_agent.py
@@ -1,9 +1,7 @@
 import os 
 import logging
-from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
-from cmbagent.utils import yaml_load_file,GPTAssistantAgent,AssistantAgent,UserProxyAgent,LocalCommandLineCodeExecutor,GroupChat,default_groupchat_intro_message,file_search_max_num_results
-import sys
-from autogen.agentchat import Agent, ConversableAgent, UpdateSystemMessage
+from cmbagent.utils import yaml_load_file,GPTAssistantAgent,UserProxyAgent,LocalCommandLineCodeExecutor,file_search_max_num_results
+from autogen.agentchat import ConversableAgent, UpdateSystemMessage
 # from autogen.cmbagent_utils import cmbagent_debug
 import autogen
 import copy

--- a/cmbagent/cmbagent.py
+++ b/cmbagent/cmbagent.py
@@ -9,26 +9,24 @@ import pandas as pd
 import copy
 import datetime
 from pathlib import Path
-from .agents.planner_response_formatter.planner_response_formatter import save_final_plan
+import time
 from collections import defaultdict
+from openai import OpenAI
+from IPython.display import Image
+from autogen.agentchat.group import ContextVariables
+from autogen.agentchat.group.patterns import AutoPattern
+
+from .agents.planner_response_formatter.planner_response_formatter import save_final_plan
 from .utils import work_dir as work_dir_default
-from .utils import OpenAI,Image
 from .utils import default_llm_model as default_llm_model_default
-from .utils import (path_to_assistants,path_to_apis,
-                    default_top_p,default_temperature,default_max_round,default_llm_config_list,default_agent_llm_configs,
-                    default_agents_llm_model, camb_context_url)
+from .utils import (path_to_assistants, path_to_apis,path_to_agents, update_yaml_preserving_format, get_model_config_from_env,
+                    default_top_p, default_temperature, default_max_round,default_llm_config_list, default_agent_llm_configs,
+                    default_agents_llm_model, camb_context_url, AAS_keywords_string)
 from .rag_utils import import_rag_agents, push_vector_stores
-from .utils import path_to_agents, update_yaml_preserving_format
 from .hand_offs import register_all_hand_offs
 from .functions import register_functions_to_agents
-import time
-from .utils import get_model_config_from_env
-from .utils import AAS_keywords_string
-from autogen.agentchat.group import ContextVariables
-
 from .data_retriever import setup_cmbagent_data
 
-from autogen.agentchat.group.patterns import AutoPattern
 
 def import_non_rag_agents():
     imported_non_rag_agents = {}

--- a/cmbagent/cmbagent.py
+++ b/cmbagent/cmbagent.py
@@ -28,9 +28,7 @@ from autogen.agentchat.group import ContextVariables
 
 from .data_retriever import setup_cmbagent_data
 
-from autogen.agentchat.group.patterns import (
-    AutoPattern,
-)
+from autogen.agentchat.group.patterns import AutoPattern
 
 def import_non_rag_agents():
     imported_non_rag_agents = {}
@@ -245,8 +243,6 @@ class CMBAgent:
         if cmbagent_debug:  
             print("\n\n Checking assistants...\n\n")
 
-
-
         if not self.skip_rag_agents:
             setup_cmbagent_data()
 
@@ -254,8 +250,6 @@ class CMBAgent:
 
             if cmbagent_debug:
                 print("\n\n Assistants checked!!!\n\n")
-                # sys.exit()
-
 
             if cmbagent_debug:
                 print('\npushing vector stores...')
@@ -266,10 +260,8 @@ class CMBAgent:
             print('\nmodify if you want to tune the instruction prompt...')
         self.set_planner_instructions() # set planner instructions
 
-
         if self.verbose or cmbagent_debug:
             print("\nSetting up agents:----------------------------------")
-
 
         # then we set the agents, note that self.agents is set in init_agents
         for agent in self.agents:
@@ -530,7 +522,6 @@ class CMBAgent:
                 one_shot_shared_context['perplexity_query'] = self.get_agent_object_from_name('perplexity').info['instructions'].format(main_task=task)
                 # print('one_shot_shared_context: ', one_shot_shared_context)
 
-
             this_shared_context.update(one_shot_shared_context)
             this_shared_context.update(shared_context or {})
 
@@ -570,17 +561,13 @@ class CMBAgent:
 
         context_variables = ContextVariables(data=this_shared_context)
 
-
-
-
-            # Create the pattern
+        # Create the pattern
         agent_pattern = AutoPattern(
                 agents=[agent.agent for agent in self.agents],
                 initial_agent=self.get_agent_from_name(initial_agent),
                 context_variables=context_variables,
                 group_manager_args = {"llm_config": self.llm_config},
             )
-
 
         chat_result, context_variables, last_agent = initiate_group_chat(
             pattern=agent_pattern,
@@ -589,15 +576,10 @@ class CMBAgent:
             max_rounds = max_rounds,
         )
 
-
         self.final_context = copy.deepcopy(context_variables)
 
         self.last_agent = last_agent
         self.chat_result = chat_result
-
-
-
-        
 
     def get_agent_object_from_name(self,name):
         for agent in self.agents:
@@ -641,9 +623,6 @@ class CMBAgent:
             print('self.agent_classes: ', self.agent_classes)
             print('self.rag_agent_names: ', self.rag_agent_names)
             print('self.non_rag_agent_names: ', self.non_rag_agent_names)
-            # import sys; sys.exit()
-
-
 
         if cmbagent_debug:
             print('self.agent_classes after update: ')
@@ -651,12 +630,9 @@ class CMBAgent:
             for agent_class, value in self.agent_classes.items():
                 print(f'{agent_class}: {value}')
                 print()
-            # sys.exit()
 
         # all agents
-
         self.agents = []
-
 
         if self.agent_list is None:
             self.agent_list = list(self.agent_classes.keys())
@@ -670,7 +646,6 @@ class CMBAgent:
             for agent_class, value in self.agent_classes.items():
                 print(f'{agent_class}: {value}')
                 print()
-            # sys.exit()
 
         # remove agents that are not set to be skipped
         if self.skip_memory:
@@ -689,7 +664,6 @@ class CMBAgent:
             for agent_class, value in self.agent_classes.items():
                 print(f'{agent_class}: {value}')
                 print()
-            # sys.exit()
 
         # instantiate the agents and llm_configs
         if cmbagent_debug:
@@ -724,8 +698,6 @@ class CMBAgent:
 
             agent_instance = agent_class(llm_config=llm_config,agent_type=self.agent_type, work_dir=self.work_dir)
 
-            # sys.exit()
-
             if cmbagent_debug:
                 print('agent_type: ', agent_instance.agent_type)
 
@@ -749,9 +721,6 @@ class CMBAgent:
                 print('agent.llm_config: ', agent.llm_config)
                 print('\n\n')
 
-        # sys.exit()
-
-
         if self.verbose or cmbagent_debug:
 
             print("Using following agents: ", self.agent_names)
@@ -759,7 +728,6 @@ class CMBAgent:
             for agent in self.agents:
                 print(f"{agent.name}: {agent.llm_config['config_list'][0]['model']}")
             print()
-            # sys.exit()
 
     def create_assistant(self, client, agent):
 
@@ -872,7 +840,6 @@ class CMBAgent:
         cache_dir = autogen.oai.client.LEGACY_CACHE_DIR
         if os.path.exists(cache_dir):
             shutil.rmtree(cache_dir)
-        # sys.exit()s
         return None
         #  autogen.Completion.clear_cache(self.cache_seed) ## obsolete AttributeError: module 'autogen' has no attribute 'Completion'
 
@@ -1413,7 +1380,6 @@ def control(
     # Now call display_cost without triggering the AttributeError
     cmbagent.display_cost()
 
-
     return results
 
 def one_shot(
@@ -1594,11 +1560,6 @@ def human_in_the_loop(task,
         json.dump(timing_report, f, indent=2)   
 
     return results
-
-
-
-
-
 
 def get_keywords(input_text: str, n_keywords: int = 5, work_dir = work_dir_default):
     """

--- a/cmbagent/cmbagent.py
+++ b/cmbagent/cmbagent.py
@@ -3,14 +3,11 @@ import logging
 import importlib
 import requests
 import autogen 
-import ast
 import json
 import sys
 import pandas as pd
 import copy
 import datetime
-from typing import Any, Dict
-from IPython.display import display
 from pathlib import Path
 from .agents.planner_response_formatter.planner_response_formatter import save_final_plan
 from collections import defaultdict
@@ -20,7 +17,6 @@ from .utils import default_llm_model as default_llm_model_default
 from .utils import (path_to_assistants,path_to_apis,
                     default_top_p,default_temperature,default_max_round,default_llm_config_list,default_agent_llm_configs,
                     default_agents_llm_model, camb_context_url)
-from pprint import pprint
 from .rag_utils import import_rag_agents, push_vector_stores
 from .utils import path_to_agents, update_yaml_preserving_format
 from .hand_offs import register_all_hand_offs
@@ -29,7 +25,6 @@ import time
 from .utils import get_model_config
 from .utils import AAS_keywords_string
 from autogen.agentchat.group import ContextVariables
-from autogen import ConversableAgent
 
 
 from .data_retriever import setup_cmbagent_data
@@ -37,11 +32,7 @@ from .data_retriever import setup_cmbagent_data
 
 
 from autogen.agentchat.group.patterns import (
-    DefaultPattern,
-    ManualPattern,
     AutoPattern,
-    RandomPattern,
-    RoundRobinPattern,
 )
 
 
@@ -68,11 +59,9 @@ def import_non_rag_agents():
     return imported_non_rag_agents
 
 
-from pydantic import BaseModel
 from autogen import cmbagent_debug
 from autogen.agentchat import initiate_group_chat
 from cmbagent.context import shared_context as shared_context_default
-from sys import exit
 import shutil
 
 
@@ -412,8 +401,6 @@ class CMBAgent:
     def display_cost(self, name_append = None):
         """Display a full cost report as a right‑aligned Markdown table with $ and a
         rule above the total row. Also saves the cost data as JSON in the workdir."""
-        from collections import defaultdict
-        import pandas as pd
         import json
 
         cost_dict = defaultdict(list)
@@ -861,7 +848,7 @@ class CMBAgent:
                         print('in cmbagent.py check_assistants: this assistant model from llm_config: ', agent.llm_config['config_list'][0]['model'])
                     if assistant_models[assistant_names.index(agent.name)] != agent.llm_config['config_list'][0]['model']:
                         if cmbagent_debug:
-                            print(f"in cmbagent.py check_assistants: Assistant model from openai does not match the requested model. Updating the assistant model.")
+                            print("in cmbagent.py check_assistants: Assistant model from openai does not match the requested model. Updating the assistant model.")
                         client.beta.assistants.update(
                             assistant_id=assistant_ids[assistant_names.index(agent.name)],
                             model=agent.llm_config['config_list'][0]['model']
@@ -883,7 +870,7 @@ class CMBAgent:
 
                         if assistant_id != assistant_ids[assistant_names.index(agent.name)]:
                             if cmbagent_debug:
-                                print(f"--> Assistant ID between yaml and openai do not match.")
+                                print("--> Assistant ID between yaml and openai do not match.")
                                 print(f"--> Assistant ID from your yaml: {assistant_id}")
                                 print(f"--> Assistant ID in openai: {assistant_ids[assistant_names.index(agent.name)]}")
                                 print("--> We will use the assistant id from openai")
@@ -1088,7 +1075,7 @@ def planning_and_control_context_carryover(
         initialization_time_control = end_time - start_time
         
         if step == 1:
-            plan_input = load_plan(os.path.join(work_dir, f"planning/final_plan.json"))["sub_tasks"]
+            plan_input = load_plan(os.path.join(work_dir, "planning/final_plan.json"))["sub_tasks"]
             agent_for_step = plan_input[0]['sub_task_agent']
         else:
             agent_for_step = current_context['agent_for_sub_task']

--- a/cmbagent/cmbagent.py
+++ b/cmbagent/cmbagent.py
@@ -915,7 +915,7 @@ def planning_and_control_context_carryover(
                             idea_hater_model = default_agents_llm_model['idea_hater'],
                             default_llm_model = default_llm_model_default,
                             work_dir = work_dir_default,
-                            configs = None,
+                            config = None,
                             ):
 
     ## planning
@@ -923,12 +923,12 @@ def planning_and_control_context_carryover(
 
     start_time = time.time()
 
-    if configs is None:
+    if config is None:
         planner_config = get_model_config_from_env(planner_model)
         plan_reviewer_config = get_model_config_from_env(plan_reviewer_model)
     else:
-        planner_config = configs["planner"]
-        plan_reviewer_config = configs["plan_reviewer"]
+        planner_config = config["planner"]
+        plan_reviewer_config = config["plan_reviewer"]
     
     cmbagent = CMBAgent(work_dir = planning_dir,
                         default_llm_model = default_llm_model,
@@ -972,16 +972,16 @@ def planning_and_control_context_carryover(
     
 
     ## control
-    if configs is None:
+    if config is None:
         engineer_config = get_model_config_from_env(engineer_model)
         researcher_config = get_model_config_from_env(researcher_model)
         idea_maker_config = get_model_config_from_env(idea_maker_model)
         idea_hater_config = get_model_config_from_env(idea_hater_model)
     else:
-        engineer_config = configs["engineer"]
-        researcher_config = configs["researcher"]
-        idea_maker_config = configs["idea_maker"]
-        idea_hater_config = configs["idea_hater"]
+        engineer_config = config["engineer"]
+        researcher_config = config["researcher"]
+        idea_maker_config = config["idea_maker"]
+        idea_hater_config = config["idea_hater"]
         
     control_dir = Path(work_dir).expanduser().resolve() / "control"
 
@@ -1134,7 +1134,7 @@ def planning_and_control(
                             idea_maker_model = default_agents_llm_model['idea_maker'],
                             idea_hater_model = default_agents_llm_model['idea_hater'],
                             work_dir = work_dir_default,
-                            configs = None,
+                            config = None,
                             ):
 
     ## planning
@@ -1142,12 +1142,12 @@ def planning_and_control(
 
     start_time = time.time()
     
-    if configs is None:
+    if config is None:
         planner_config = get_model_config_from_env(planner_model)
         plan_reviewer_config = get_model_config_from_env(plan_reviewer_model)
     else:
-        planner_config = configs["planner"]
-        plan_reviewer_config = configs["plan_reviewer"]
+        planner_config = config["planner"]
+        plan_reviewer_config = config["plan_reviewer"]
 
     cmbagent = CMBAgent(work_dir = planning_dir,
                         agent_llm_configs = {
@@ -1188,16 +1188,16 @@ def planning_and_control(
     print(f"Planning took {execution_time_planning:.4f} seconds")
     
     ## control
-    if configs is None:
+    if config is None:
         engineer_config = get_model_config_from_env(engineer_model)
         researcher_config = get_model_config_from_env(researcher_model)
         idea_maker_config = get_model_config_from_env(idea_maker_model)
         idea_hater_config = get_model_config_from_env(idea_hater_model)
     else:
-        engineer_config = configs["engineer"]
-        researcher_config = configs["researcher"]
-        idea_maker_config = configs["idea_maker"]
-        idea_hater_config = configs["idea_hater"]
+        engineer_config = config["engineer"]
+        researcher_config = config["researcher"]
+        idea_maker_config = config["idea_maker"]
+        idea_hater_config = config["idea_hater"]
         
     control_dir = Path(work_dir).expanduser().resolve() / "control"
 
@@ -1294,7 +1294,7 @@ def control(
             idea_hater_model = default_agents_llm_model['idea_hater'],
             work_dir = work_dir_default,
             clear_work_dir = True,
-            configs = None,
+            config = None,
             ):
     
     # check work_dir exists
@@ -1312,16 +1312,16 @@ def control(
         context["current_instructions"] += f"\t\t- {bullet}\n"
 
     ## control
-    if configs is None:
+    if config is None:
         engineer_config = get_model_config_from_env(engineer_model)
         researcher_config = get_model_config_from_env(researcher_model)
         idea_maker_config = get_model_config_from_env(idea_maker_model)
         idea_hater_config = get_model_config_from_env(idea_hater_model)
     else:
-        engineer_config = configs["engineer"]
-        researcher_config = configs["researcher"]
-        idea_maker_config = configs["idea_maker"]
-        idea_hater_config = configs["idea_hater"]
+        engineer_config = config["engineer"]
+        researcher_config = config["researcher"]
+        idea_maker_config = config["idea_maker"]
+        idea_hater_config = config["idea_hater"]
         
     control_dir = Path(work_dir).expanduser().resolve() / "control"
 
@@ -1390,16 +1390,16 @@ def one_shot(
             researcher_model = default_agents_llm_model['researcher'],
             agent = 'engineer',
             work_dir = work_dir_default,
-            configs = None,
+            config = None,
             ):
     start_time = time.time()
 
-    if configs is None:
+    if config is None:
         engineer_config = get_model_config_from_env(engineer_model)
         researcher_config = get_model_config_from_env(researcher_model)
     else:
-        engineer_config = configs["engineer"]
-        researcher_config = configs["researcher"]
+        engineer_config = config["engineer"]
+        researcher_config = config["researcher"]
         
     cmbagent = CMBAgent(
         mode = "one_shot",
@@ -1487,18 +1487,18 @@ def human_in_the_loop(task,
          engineer_model = 'gpt-4o-2024-11-20',
          researcher_model = 'gpt-4o-2024-11-20',
          agent = 'engineer',
-         configs = None,
+         config = None,
          ):
 
     ## control
     start_time = time.time()
 
-    if configs is None:
+    if config is None:
         engineer_config = get_model_config_from_env(engineer_model)
         researcher_config = get_model_config_from_env(researcher_model)
     else:
-        engineer_config = configs["engineer"]
-        researcher_config = configs["researcher"]
+        engineer_config = config["engineer"]
+        researcher_config = config["researcher"]
 
     cmbagent = CMBAgent(
         work_dir = work_dir,

--- a/cmbagent/context.py
+++ b/cmbagent/context.py
@@ -1,4 +1,3 @@
-from .utils import AAS_keywords_string
 shared_context = {
 
     "plans": [],

--- a/cmbagent/functions.py
+++ b/cmbagent/functions.py
@@ -1,5 +1,4 @@
 from typing import Literal
-from pydantic import Field
 import os
 import re
 import ast
@@ -8,9 +7,7 @@ from IPython.display import Image as IPImage, display as ip_display
 from IPython.display import Markdown
 from autogen.cmbagent_utils import IMG_WIDTH
 import autogen
-from autogen.tools.experimental import PerplexitySearchTool
 from .utils import AAS_keywords_dict
-from typing import Any
 from autogen.agentchat.group import ContextVariables
 from autogen.agentchat.group import AgentTarget, ReplyResult, TerminateTarget
 from autogen import register_function

--- a/cmbagent/functions.py
+++ b/cmbagent/functions.py
@@ -7,13 +7,13 @@ from IPython.display import Image as IPImage, display as ip_display
 from IPython.display import Markdown
 from autogen.cmbagent_utils import IMG_WIDTH
 import autogen
-from .utils import AAS_keywords_dict
 from autogen.agentchat.group import ContextVariables
 from autogen.agentchat.group import AgentTarget, ReplyResult, TerminateTarget
 from autogen import register_function
 from typing import Optional
 import datetime
 import json
+from .utils import AAS_keywords_dict
 
 cmbagent_debug = autogen.cmbagent_debug
 cmbagent_disable_display = autogen.cmbagent_disable_display

--- a/cmbagent/gui/gui.py
+++ b/cmbagent/gui/gui.py
@@ -3,25 +3,20 @@
 import streamlit as st
 import os
 import re
-import io
 from PIL import Image
 import pandas as pd
-from IPython.display import Markdown as IPyMarkdown, Image as IPyImage
+from IPython.display import Markdown as IPyMarkdown
 # from PIL.Image import Image as PILImage  # <-- this is the actual class
 from pandas.io.formats.style import Styler
 os.environ["CMBAGENT_DEBUG"] = "false"
 os.environ["ASTROPILOT_DISABLE_DISPLAY"] = "true"
 os.environ["STREAMLIT_ON"] = "true"
 import json
-import time
-import copy
 # import cmbagent
-from cmbagent.cmbagent import CMBAgent, planning_and_control, one_shot, human_in_the_loop, planning_and_control_context_carryover
+from cmbagent.cmbagent import one_shot, planning_and_control_context_carryover
 
 import requests
-import sys
 from contextlib import redirect_stdout
-from streamlit import components
 import glob          # <-- NEW
 import traceback
 import base64
@@ -323,12 +318,11 @@ def main():
 
     # ------------------------------------------------------------------ utils/json
 
-    import tempfile, shutil
+    import tempfile
+    import shutil
     from json import JSONDecodeError
-    from datetime import datetime
     # ── utils/filenames ──────────────────────────────────────────────────────────
     import unicodedata
-    import string
 
 
 

--- a/cmbagent/hand_offs.py
+++ b/cmbagent/hand_offs.py
@@ -1,11 +1,9 @@
-from autogen.agentchat.group import NestedChatTarget, AgentTarget, TerminateTarget, OnCondition, StringLLMCondition
+from autogen.agentchat.group import AgentTarget, TerminateTarget, OnCondition, StringLLMCondition
 from autogen.cmbagent_utils import cmbagent_debug
-from typing import Any, Dict, List
 import autogen
-import os
 from autogen import GroupChatManager, GroupChat
 from autogen.agentchat.contrib.capabilities.transform_messages import TransformMessages
-from autogen.agentchat.contrib.capabilities.transforms import MessageHistoryLimiter, MessageTokenLimiter
+from autogen.agentchat.contrib.capabilities.transforms import MessageHistoryLimiter
 
 cmbagent_debug = autogen.cmbagent_utils.cmbagent_debug
 

--- a/cmbagent/literature.py
+++ b/cmbagent/literature.py
@@ -1,6 +1,6 @@
 import re
 import requests
-from typing import List, Dict, Tuple
+from typing import List, Tuple
 
 # def process_tex_file_with_references(fname_tex, fname_bib, perplexity, nparagraphs=None):
 #     """

--- a/cmbagent/rag_utils.py
+++ b/cmbagent/rag_utils.py
@@ -1,10 +1,10 @@
 import os
 import importlib
-from .utils import path_to_assistants,OpenAI,default_chunking_strategy,YAML
+from openai import OpenAI
 from autogen.cmbagent_utils import cmbagent_debug
-from .utils import update_yaml_preserving_format
 import requests
 import pprint
+from .utils import path_to_assistants,default_chunking_strategy,YAML,update_yaml_preserving_format
 
 def import_rag_agents():        
     imported_rag_agents = {}

--- a/cmbagent/rag_utils.py
+++ b/cmbagent/rag_utils.py
@@ -1,9 +1,10 @@
 import os
 import importlib
-from .utils import path_to_assistants,OpenAI,default_chunking_strategy,default_top_p,default_temperature,default_select_speaker_prompt_template,default_select_speaker_message_template, YAML
+from .utils import path_to_assistants,OpenAI,default_chunking_strategy,YAML
 from autogen.cmbagent_utils import cmbagent_debug
 from .utils import update_yaml_preserving_format
-import requests, pprint
+import requests
+import pprint
 
 def import_rag_agents():        
     imported_rag_agents = {}

--- a/cmbagent/utils.py
+++ b/cmbagent/utils.py
@@ -167,7 +167,7 @@ default_agents_llm_model ={
 
 default_agent_llm_configs = {}
 
-def get_model_config(model):
+def get_model_config_from_env(model):
     config = {
         "model": model,
         "api_key": None,
@@ -198,10 +198,10 @@ def get_model_config(model):
     return config
 
 for agent in default_agents_llm_model:
-    default_agent_llm_configs[agent] =  get_model_config(default_agents_llm_model[agent])
+    default_agent_llm_configs[agent] =  get_model_config_from_env(default_agents_llm_model[agent])
 
 
-default_llm_config_list = [get_model_config(default_llm_model)]
+default_llm_config_list = [get_model_config_from_env(default_llm_model)]
 
 
 #### note we should be able to set the temperature for different agents, e.g., 

--- a/cmbagent/utils.py
+++ b/cmbagent/utils.py
@@ -1,23 +1,14 @@
 # cmbagent/utils.py
 import os
-from openai import OpenAI
 
-from pprint import pprint
 
-from autogen.coding import LocalCommandLineCodeExecutor
 
 import autogen
-from autogen.agentchat import AssistantAgent, UserProxyAgent, GroupChat
-from autogen.agentchat.contrib.gpt_assistant_agent import GPTAssistantAgent
 from autogen.cmbagent_utils import cmbagent_debug
 
 
-from cobaya.yaml import yaml_load_file, yaml_load
 
-from IPython.display import Image
 
-import importlib
-import sys
 import pickle
 
 import logging
@@ -26,7 +17,6 @@ from ruamel.yaml import YAML
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='[%(name)s] %(message)s')
 
-import autogen
 cmbagent_debug = autogen.cmbagent_debug
 
 

--- a/cmbagent/utils.py
+++ b/cmbagent/utils.py
@@ -159,7 +159,15 @@ default_agents_llm_model ={
 
 default_agent_llm_configs = {}
 
-def get_model_config_from_env(model):
+def get_api_keys_from_env():
+    api_keys = {
+        "OPENAI" : os.getenv("OPENAI_API_KEY"),
+        "GEMINI" : os.getenv("GEMINI_API_KEY"),
+        "ANTHROPIC" : os.getenv("ANTHROPIC_API_KEY"),
+    }
+    return api_keys
+
+def get_model_config(model, api_keys):
     config = {
         "model": model,
         "api_key": None,
@@ -169,31 +177,33 @@ def get_model_config_from_env(model):
     if 'o3' in model:
         config.update({
             "reasoning_effort": "medium",
-            "api_key": os.getenv("OPENAI_API_KEY"),
+            "api_key": api_keys["OPENAI"],
             "api_type": "openai"
         })
     elif "gemini" in model:
         config.update({
-            "api_key": os.getenv("GEMINI_API_KEY"), 
+            "api_key": api_keys["GEMINI"],
             "api_type": "google"
         })
     elif "claude" in model:
         config.update({
-            "api_key": os.getenv("ANTHROPIC_API_KEY"),
+            "api_key": api_keys["ANTHROPIC"],
             "api_type": "anthropic"
         })
     else:
         config.update({
-            "api_key": os.getenv("OPENAI_API_KEY"),
+            "api_key": api_keys["OPENAI"],
             "api_type": "openai"
         })
     return config
 
+api_keys_env = get_api_keys_from_env()
+
 for agent in default_agents_llm_model:
-    default_agent_llm_configs[agent] =  get_model_config_from_env(default_agents_llm_model[agent])
+    default_agent_llm_configs[agent] =  get_model_config(default_agents_llm_model[agent], api_keys_env)
 
 
-default_llm_config_list = [get_model_config_from_env(default_llm_model)]
+default_llm_config_list = [get_model_config(default_llm_model, api_keys_env)]
 
 
 #### note we should be able to set the temperature for different agents, e.g., 

--- a/cmbagent/utils.py
+++ b/cmbagent/utils.py
@@ -1,18 +1,10 @@
 # cmbagent/utils.py
 import os
-
-
-
 import autogen
-from autogen.cmbagent_utils import cmbagent_debug
-
-
-
-
 import pickle
-
 import logging
 from ruamel.yaml import YAML
+from autogen.cmbagent_utils import cmbagent_debug
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='[%(name)s] %(message)s')

--- a/tests/test_camb_agent.py
+++ b/tests/test_camb_agent.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 
 os.environ["CMBAGENT_DEBUG"] = "false"

--- a/tests/test_camb_agent_gemini.py
+++ b/tests/test_camb_agent_gemini.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 
 os.environ["CMBAGENT_DEBUG"] = "true"

--- a/tests/test_cobaya_agent.py
+++ b/tests/test_cobaya_agent.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 
 os.environ["CMBAGENT_DEBUG"] = "false"

--- a/tests/test_engineer.py
+++ b/tests/test_engineer.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 
 os.environ["CMBAGENT_DEBUG"] = "false"

--- a/tests/test_engineer_make_plot.py
+++ b/tests/test_engineer_make_plot.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 
 os.environ["CMBAGENT_DEBUG"] = "false"

--- a/tests/test_engineer_missing_datafile.py
+++ b/tests/test_engineer_missing_datafile.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 
 os.environ["CMBAGENT_DEBUG"] = "false"

--- a/tests/test_engineer_planning_and_control.py
+++ b/tests/test_engineer_planning_and_control.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 
 os.environ["CMBAGENT_DEBUG"] = "false"

--- a/tests/test_engineer_run_codebase.py
+++ b/tests/test_engineer_run_codebase.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 
 os.environ["CMBAGENT_DEBUG"] = "false"

--- a/tests/test_hitl.py
+++ b/tests/test_hitl.py
@@ -1,9 +1,7 @@
 import os
-import re
 
 os.environ["CMBAGENT_DEBUG"] = "false"
 os.environ["ASTROPILOT_DISABLE_DISPLAY"] = "true"
-import copy
 import cmbagent
 
 

--- a/tests/test_idea_maker.py
+++ b/tests/test_idea_maker.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 
 os.environ["CMBAGENT_DEBUG"] = "false"

--- a/tests/test_idea_maker_short.py
+++ b/tests/test_idea_maker_short.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 
 os.environ["CMBAGENT_DEBUG"] = "false"

--- a/tests/test_ideas.py
+++ b/tests/test_ideas.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 
 os.environ["CMBAGENT_DEBUG"] = "false"

--- a/tests/test_perplexity_agent.py
+++ b/tests/test_perplexity_agent.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 
 os.environ["CMBAGENT_DEBUG"] = "false"

--- a/tests/test_perplexity_agent_idea_scoring.py
+++ b/tests/test_perplexity_agent_idea_scoring.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 
 os.environ["CMBAGENT_DEBUG"] = "false"

--- a/tests/test_researcher.py
+++ b/tests/test_researcher.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 
 os.environ["CMBAGENT_DEBUG"] = "true"

--- a/tests/test_researcher_engineer_3steps.py
+++ b/tests/test_researcher_engineer_3steps.py
@@ -1,7 +1,6 @@
 import copy
 
 import os
-import re
 os.environ["CMBAGENT_DEBUG"] = "false"
 os.environ["CMBAGENT_DISABLE_DISPLAY"] = "true"
 

--- a/tests/test_researcher_engineer_3steps_with_error.py
+++ b/tests/test_researcher_engineer_3steps_with_error.py
@@ -1,7 +1,6 @@
 import copy
 
 import os
-import re
 os.environ["CMBAGENT_DEBUG"] = "false"
 os.environ["CMBAGENT_DISABLE_DISPLAY"] = "true"
 

--- a/tests/test_researcher_engineer_5steps.py
+++ b/tests/test_researcher_engineer_5steps.py
@@ -1,9 +1,6 @@
 import os
-import re
 
 
-import os
-import re
 os.environ["CMBAGENT_DEBUG"] = "false"
 os.environ["CMBAGENT_DISABLE_DISPLAY"] = "true"
 

--- a/tests/test_researcher_planning_and_control.py
+++ b/tests/test_researcher_planning_and_control.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 
 os.environ["CMBAGENT_DEBUG"] = "false"

--- a/tests/test_various_plans.py
+++ b/tests/test_various_plans.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 
 os.environ["CMBAGENT_DEBUG"] = "false"


### PR DESCRIPTION
This PR allow to indicate the API keys as an argument, which simplifies the pipeline for deployment. The previous way to load from the environment is still supported and is the default choice if no keys are provided.
Also some cleaning and formatting improvements.