### PR TITLE
Add flag for settings when deployment and use different folders per process for deployment

### DIFF
--- a/cmbagent/cli.py
+++ b/cmbagent/cli.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 from importlib.util import find_spec
 
-def run_gui():
+def run_gui(deploy: bool):
     # Get the installed file path to cmbagent.cli
     gui_spec = find_spec("cmbagent.cli")
     if gui_spec is None or gui_spec.origin is None:
@@ -47,7 +47,10 @@ def run_gui():
             f.write(theme_config)
 
     # Run the Streamlit GUI
-    sys.exit(subprocess.call(["streamlit", "run", gui_path + "gui.py"]))
+    command = ["streamlit", "run", gui_path + "gui.py"]
+    if deploy:
+        command.extend(["--","--deploy"])
+    sys.exit(subprocess.call(command))
 
 
 def main():
@@ -55,9 +58,12 @@ def main():
     parser = argparse.ArgumentParser(prog="cmbagent")
     subparsers = parser.add_subparsers(dest="command")
     subparsers.add_parser("run", help="Launch the CMBAGENT Streamlit GUI")
+    subparsers.add_parser("deploy", help="Flag to enable special settings for deployment in Huggin Face Spaces")
     args = parser.parse_args()
 
     if args.command == "run":
-        run_gui()
+        run_gui(False)
+    elif args.command == "deploy":
+        run_gui(True)
     else:
         parser.print_help()

--- a/cmbagent/cmbagent.py
+++ b/cmbagent/cmbagent.py
@@ -17,7 +17,7 @@ from autogen.agentchat.group import ContextVariables
 from autogen.agentchat.group.patterns import AutoPattern
 
 from .agents.planner_response_formatter.planner_response_formatter import save_final_plan
-from .utils import work_dir as work_dir_default
+from .utils import work_dir_default
 from .utils import default_llm_model as default_llm_model_default
 
 from .utils import (path_to_assistants, path_to_apis,path_to_agents, update_yaml_preserving_format, get_model_config,

--- a/cmbagent/gui/gui.py
+++ b/cmbagent/gui/gui.py
@@ -22,12 +22,24 @@ import glob          # <-- NEW
 import traceback
 import base64
 from pathlib import Path
+import uuid
+import argparse
 
 IMAGE_WIDTH_FRACTION = 1/2
 
 # ── rolling memory: only used in HUMAN‑IN‑THE‑LOOP mode ───────────────
 from collections import deque
 
+def get_project_dir():
+
+    if "project_dir" not in st.session_state:
+        
+        temp_dir = f"project_{uuid.uuid4().hex}"
+        os.makedirs(temp_dir, exist_ok=True)
+        
+        st.session_state.project_dir = temp_dir
+
+    return st.session_state.project_dir
 
 def main():
     from PIL.Image import Image as PILImage
@@ -150,6 +162,15 @@ def main():
     #     initial_sidebar_state="auto"
     # )
 
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--deploy',action='store_true',help='Flag to enable special settings for deployment in Huggin Face Spaces')
+    deploy = parser.parse_args().deploy
+
+    if deploy:
+        project_dir = get_project_dir()
+    else:
+        project_dir = "project_dir"
+
     cmbagent_logo_path = os.path.join(os.path.dirname(__file__), "..", "logo.png")
     st.set_page_config(
         page_title="CMBAGENT",
@@ -157,7 +178,6 @@ def main():
         layout="wide",
         initial_sidebar_state="auto"
     )
-
 
     st.markdown("""
     <link href='https://fonts.googleapis.com/css?family=Jersey+10' rel='stylesheet'>
@@ -665,15 +685,16 @@ def main():
         with st.expander("Click to configure", expanded=False):
 
             # 📝  Tell users they can skip the boxes if their keys are already exported
-            st.markdown(
-                """
-                <span style="font-size:0.9rem;">
-                <em>If you’ve already set your API keys as environment variables
-                (e.g., in <code>~/.bashrc</code>), leave these fields blank.</em>
-                </span>
-                """,
-                unsafe_allow_html=True,
-            )
+            if not deploy:
+                st.markdown(
+                    """
+                    <span style="font-size:0.9rem;">
+                    <em>If you’ve already set your API keys as environment variables
+                    (e.g., in <code>~/.bashrc</code>), leave these fields blank.</em>
+                    </span>
+                    """,
+                    unsafe_allow_html=True,
+                )
             st.markdown("<br>", unsafe_allow_html=True)
 
             provider_oai        = st.text_input("OpenAI",      type="password", key="api_key_oai")
@@ -1157,7 +1178,8 @@ def main():
                                 engineer_model = engineer_model,
                                 researcher_model = researcher_model,
                                 agent = st.session_state.one_shot_selected_agent,
-                                api_keys = api_keys
+                                api_keys = api_keys,
+                                work_dir = project_dir,
                             )
 
                         elif st.session_state.page == "planning_and_control":
@@ -1171,7 +1193,8 @@ def main():
                                 researcher_model = researcher_model,
                                 plan_instructions = plan_instructions,
                                 hardware_constraints = hardware_constraints,
-                                api_keys = api_keys
+                                api_keys = api_keys,
+                                work_dir = project_dir,
                             )
 
                         elif st.session_state.page == "human_in_the_loop":
@@ -1185,7 +1208,8 @@ def main():
                                 engineer_model   = engineer_model,
                                 researcher_model = researcher_model,
                                 agent    = st.session_state.one_shot_selected_agent,
-                                api_keys = api_keys
+                                api_keys = api_keys,
+                                work_dir = project_dir,
                             )
 
 

--- a/cmbagent/utils.py
+++ b/cmbagent/utils.py
@@ -35,14 +35,14 @@ path_to_agents = os.path.join(path_to_basedir, "agents/")
 # path_to_admin = os.path.join(path_to_basedir, "admin")
 
 if "site-packages" in path_to_basedir or "dist-packages" in path_to_basedir:
-    work_dir = os.path.join(os.getcwd(), "cmbagent_output")
-    if not os.path.exists(work_dir):
-        os.makedirs(work_dir)
+    work_dir_default = os.path.join(os.getcwd(), "cmbagent_output")
+    if not os.path.exists(work_dir_default):
+        os.makedirs(work_dir_default)
 else:
-    work_dir = os.path.join(path_to_basedir, "../output")
+    work_dir_default = os.path.join(path_to_basedir, "../output")
 
 if cmbagent_debug:
-    print('\n\n\n\n\nwork_dir: ', work_dir)
+    print('\n\n\n\n\nwork_dir_default: ', work_dir_default)
 
 
 default_chunking_strategy = {


### PR DESCRIPTION
This PR avoids that all users share the same working directory in the deployed app in HugginFace Spaces, creating different folders per instance.