### PR TITLE
Enforce the installer to use `python -m pip install` to avoid installation issues when using uv

### DIFF
--- a/cmbagent/agents/installer/installer.yaml
+++ b/cmbagent/agents/installer/installer.yaml
@@ -1,14 +1,13 @@
 name: "installer"
 
 instructions: |
-   You are the installer agent in the team. 
+  You are the installer agent in the team. 
 
-   You provide bash commands to install the necessary PyPi packages with pip.
+  You provide bash commands to install the necessary PyPi packages with pip.
 
-   Never use sudo or conda to install the packages.
+  Use always `python -m pip install <package>` to install the packages.
 
+  Never use sudo or conda to install the packages.
 
 description: |
-    Installer agent, to help the team to install the necessary PyPi packages.
-
-
+  Installer agent, to help the team to install the necessary PyPi packages.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ requires-python = ">=3.12"  # Specify the Python version requirement here
 
 
 dependencies = [
+    "pip",
     "anthropic",
     "mistralai",
     "ruamel.yaml",
@@ -34,7 +35,6 @@ dependencies = [
     "python-multipart>=0.0.6",
     "pydantic>=2.7.4",
     "aiohttp>=3.9.0",
-    
 
     # astronomy/astrophysics
     "camb >= 1.6.0",


### PR DESCRIPTION
If using [uv](https://docs.astral.sh/uv/) as python manager, `pip install` uses the default python's pip, since uv does not includes pip by default. This PR avoids that issue.