### PR TITLE
Distinguish code vs step execution status

### DIFF
--- a/cmbagent/agents/coding/executor_response_formatter/executor_response_formatter.yaml
+++ b/cmbagent/agents/coding/executor_response_formatter/executor_response_formatter.yaml
@@ -3,15 +3,21 @@ name: "executor_response_formatter"
 instructions: |
 
     You call your tool post_execution_transfer.
+
+    **IMPORTANT:** You report the CODE execution status, not whether the step is complete.
+    - execution_status="success" means the code/command ran without errors
+    - execution_status="failure" means there was an error during execution
+
+    The CONTROLLER decides if the step goal is achieved, not you.
+
     For the next agent suggestion, follow these rules:
 
         - Suggest the installer agent if error related to missing Python modules (i.e., ModuleNotFoundError).
         - Suggest the camb_context agent if CAMB documentation should be consulted.
         - Suggest camb_context to fix Python errors related to the camb code.
         - Suggest the engineer agent if error related to generic Python code. Don't prioritize the engineer agent if the error is related to the camb code, in this case suggest camb_context instead.
-        - Suggest the controller only if execution was successful. 
-    
+        - Suggest the controller if execution was successful (controller will evaluate if step is complete).
 
 
 description: |
-   Process the response provided by the executor agent.
+   Process the response provided by the executor agent. Reports code execution status to the controller.

--- a/cmbagent/agents/control/controller/controller.yaml
+++ b/cmbagent/agents/control/controller/controller.yaml
@@ -5,6 +5,15 @@ instructions: |
 
     You must call record_status **before** calling the agent in charge of the up-coming sub-task.
 
+    **IMPORTANT: Distinguish between code execution status and step completion:**
+    - `code_execution_status`: Whether code/commands ran without errors ("success"/"failure")
+    - `step_execution_status`: Whether the plan step GOAL is achieved
+
+    **Only mark a step as "completed" when the actual step goal is achieved**, not just when code runs successfully!
+    - Package installation success → step is NOT complete, continue with main task
+    - Debugging/fix success → step is NOT complete, verify the fix works
+    - Main task code runs and produces expected output → step IS complete
+
     You follow step-by-step the established plan:
 
     {final_plan}
@@ -16,6 +25,9 @@ instructions: |
 
     **Current status:**
     {current_status}
+
+    **Code execution status:**
+    {code_execution_status}
 
     **Current sub-task:**
     {current_sub_task}
@@ -37,7 +49,7 @@ instructions: |
     -----------------------------------
     </PREVIOUS_STEPS_EXECUTION_SUMMARY>
 
-    After sucessful installation of a Python package, you must call the engineer agent to check if the code can be run.
+    After successful installation of a Python package, you must call the engineer agent to check if the code can be run.
 
 description: |
     Controller agent, to control the plan implementation.

--- a/cmbagent/context.py
+++ b/cmbagent/context.py
@@ -29,9 +29,15 @@ shared_context = {
     "current_plan_step_number": None,
     "current_sub_task": None,
     "agent_for_sub_task": None,
-    "current_status": None,
+    "current_status": None,  # Controller's view of step status: "in progress", "completed", "failed"
     "current_instructions": None,
     "previous_steps_execution_summary": "\n",
+
+    # Step vs Code execution status distinction:
+    # - code_execution_status: Result of running code/commands ("success"/"failure")
+    # - step_execution_status: Whether the plan step goal is achieved (only controller sets "completed")
+    "step_execution_status": "pending",  # "pending", "in_progress", "completed"
+    "code_execution_status": None,  # "success", "failure" - set by executor
 
     # =========================================================================
     # Agent Handoff Flags

--- a/cmbagent/functions/status.py
+++ b/cmbagent/functions/status.py
@@ -40,6 +40,16 @@ def _update_context_variables(
     context_variables["current_instructions"] = current_instructions
     context_variables["current_status"] = current_status
 
+    # Update step_execution_status based on current_status
+    # Only the controller (via record_status) can mark a step as "completed"
+    if current_status == "completed":
+        context_variables["step_execution_status"] = "completed"
+    elif current_status == "in progress":
+        context_variables["step_execution_status"] = "in_progress"
+    # Reset code_execution_status when starting new work
+    if current_status == "in progress":
+        context_variables["code_execution_status"] = None
+
 
 def _load_codebase_info(cmbagent_instance, context_variables: ContextVariables) -> str:
     """Load and format docstrings from codebase."""
@@ -176,6 +186,9 @@ def _determine_next_agent_default(cmbagent_instance, context_variables: ContextV
 
 def _format_status_message(context_variables: ContextVariables, icon: str) -> str:
     """Format the status message."""
+    code_status = context_variables.get("code_execution_status", "N/A")
+    step_status = context_variables.get("step_execution_status", "pending")
+
     return f"""
 **Step number:** {context_variables["current_plan_step_number"]} out of {context_variables["number_of_steps_in_plan"]}.
 
@@ -187,7 +200,11 @@ def _format_status_message(context_variables: ContextVariables, icon: str) -> st
 
 {context_variables["current_instructions"]}
 
-**Status:** {context_variables["current_status"]} {icon}
+**Controller status:** {context_variables["current_status"]} {icon}
+
+**Code execution status:** {code_status}
+
+**Step execution status:** {step_status}
         """
 
 

--- a/tests/test_deep_research.py
+++ b/tests/test_deep_research.py
@@ -13,7 +13,7 @@ def test_deep_research():
         task,
         max_rounds_control=100,
         n_plan_reviews=1,
-        max_n_attempts=2,
+        max_n_attempts=4,
         max_plan_steps=4,
         # engineer_model="gemini-3-flash-preview",
         # engineer_model="gemini-2.5-flash",

--- a/tests/test_one_shot_engineer_oss.py
+++ b/tests/test_one_shot_engineer_oss.py
@@ -8,9 +8,15 @@ def test_one_shot_engineer_oss():
     Plot the histogram of the numbers.
     """
 
+    task = r"""
+    Analyse /Users/boris/Desktop/data/Stocks.csv file using pandas.
+    and then plot relevant statistics with matplotlib.
+    """
+
     results = cmbagent.one_shot(
         task,
-        max_rounds=10,
+        max_rounds=25,
+        max_n_attempts=10,
         agent="engineer",
         engineer_model="gpt-oss-120b",
         default_formatter_model="gpt-oss-120b",


### PR DESCRIPTION
Separate code execution status from plan step completion and propagate that through the agent workflow. Updates:

- executor_response_formatter.yaml: instruct executor to report CODE execution_status (success/failure) and recommend controller evaluates step completion.
- controller.yaml: clarify that controller must decide when a step is marked completed and show code_execution_status in prompts.
- context.py: add step_execution_status and code_execution_status to shared_context and document their meanings.
- execution_control.py: store code_execution_status in context, adjust handoff messages to emphasize the controller should evaluate step completion, and keep routing logic consistent.
- status.py: update _update_context_variables to set step_execution_status from current_status, reset code_execution_status when work starts, and include both statuses in formatted status messages.
- tests: increase allowed attempts/rounds (deep_research max_n_attempts 2->4; one_shot_engineer_oss adds a CSV task and raises max_rounds and max_n_attempts).

These changes ensure agents report whether code ran without errors while leaving the controller responsible for declaring whether the plan step goal was actually achieved.